### PR TITLE
add option to set default shell in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ vim.keymap.set({ "n", "t" }, "<C-g>", "<cmd> Term lazygit <CR>")
 There are only two configuration options: `size` and `shell`.
 
 `size` controlls how big will be the popup window. Takes values from `0.0` to `1.0` (defaults to 0.9).
-`shell` controlls which shell you would like to open (bash, zsh, tmux, etc.) if you don't pass any arguments to `:Term` (defaults to `bash`)
+`shell` controls which default shell to open (bash, zsh, tmux, etc.) when no arguments are passed to `:Term` (defaults to `bash`)
 
 **Set the size value to `1` for a full screen terminal popup.**
 

--- a/README.md
+++ b/README.md
@@ -45,15 +45,16 @@ vim.keymap.set({ "n", "t" }, "<C-g>", "<cmd> Term lazygit <CR>")
 
 ## 🔧 Configuration
 
-There is only one configuration option: `size`.
+There are only two configuration options: `size` and `shell`.
 
-It controlls how big will be the popup window. Takes values from `0.0` to `1.0` (defaults to 0.9).
+`size` controlls how big will be the popup window. Takes values from `0.0` to `1.0` (defaults to 0.9).
+`shell` controlls which shell you would like to open (bash, zsh, tmux, etc.) if you don't pass any arguments to `:Term` (defaults to `bash`)
 
 **Set the size value to `1` for a full screen terminal popup.**
 
 - For [folke/lazy.nvim](https://github.com/folke/lazy.nvim)
 ```lua
-{ "Ernest1338/termplug.nvim", config = { size = 0.5 } },
+{ "Ernest1338/termplug.nvim", config = { size = 0.5, shell = "zsh" } },
 ```
 
 - For [wbthomason/packer.nvim](https://github.com/wbthomason/packer.nvim)
@@ -61,7 +62,7 @@ It controlls how big will be the popup window. Takes values from `0.0` to `1.0` 
 use {
     "Ernest1338/termplug.nvim",
     config = function()
-        require("termplug").setup{ size = 0.5 }
+        require("termplug").setup{ size = 0.5, shell = "tmux" }
     end
 }
 ```
@@ -70,7 +71,7 @@ use {
 ```lua
 later(function()
     add("Ernest1338/termplug.nvim")
-    require("termplug").setup({ size = 0.5 })
+    require("termplug").setup({ size = 0.5, shell = "fish" })
 end)
 ```
 

--- a/lua/termplug.lua
+++ b/lua/termplug.lua
@@ -4,6 +4,7 @@ local api = vim.api
 
 local buffers, windows = {}, {}
 local size = 0.9
+local shell = "bash"
 local window_currently_opened = false
 
 function M.get_float_config()
@@ -69,9 +70,6 @@ function M.create_window(process)
 end
 
 function M.toggle(process)
-    if process == nil then
-        process = "bash"
-    end
     local t_buffer = buffers[process]
     if t_buffer == nil or not api.nvim_buf_is_valid(t_buffer) then
         if window_currently_opened == true then return end
@@ -102,11 +100,14 @@ function M.setup(opts)
     opts = opts or {}
 
     size = opts.size or size
+    shell = opts.shell or shell
 
     api.nvim_create_user_command("Term", function(input)
-        local process = input.args
-        if #process == 0 then
-            process = nil
+        local process
+        if #input.args == 0 then
+            process = shell
+        else
+            process = input.args
         end
         M.toggle(process)
     end, { force = true, nargs = "*" })


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a new configuration option to set the default shell in the Termplug plugin, updating the README to document this feature and provide usage examples.

New Features:
- Introduce a configuration option to set the default shell in the Termplug plugin, allowing users to specify which shell to open if no arguments are passed to the :Term command.

Documentation:
- Update the README to include the new 'shell' configuration option, explaining its purpose and providing examples of how to set it in different plugin managers.

<!-- Generated by sourcery-ai[bot]: end summary -->